### PR TITLE
set descriptions from docstrings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 Unreleased
 
+-   The description for a model's object, and for an attribute's field and
+    argument, is set from their docstrings. :issue:`19`
+
 
 ## Version 1.0.0
 

--- a/docs/model.md
+++ b/docs/model.md
@@ -81,3 +81,25 @@ Two types of validators are automatically generated as needed:
 -   For each relationship, a validator will check that the given primary keys
     exist, for to-one and to-many relationships. See
     {class}`.ItemExistsValidator` and {class}`.ListExistsValidator`.
+
+
+## Documentation
+
+Descriptions are automatically taken from docstrings:
+
+-   A model docstring is used as the object description.
+-   An attribute docstring is used as the field, create, and update argument
+    descriptions.
+
+```python
+class Task(Model):
+    """A task describes work to be done."""
+
+    __tablename__ = "task"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    description: Mapped[str]
+    """What to do."""
+    user_id: Mapped[int] = mapped_column(ForeignKey(User.id))
+    user: Mapped[User] = relationship()
+    """The user doing the task."""
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,15 +27,19 @@ class Model(sa_orm.DeclarativeBase):
 
 
 class User(Model):
+    """A user."""
+
     __tablename__ = "user"
     id: Mapped[int] = mapped_column(primary_key=True)
     username: Mapped[str] = mapped_column(unique=True)
+    """The unique name used to log in the user."""
     tasks: Mapped[list[Task]] = relationship(
         foreign_keys="Task.user_id", back_populates="user"
     )
     tagged_tasks: Mapped[list[Task]] = relationship(
         foreign_keys="Task.tagged_user_id", back_populates="tagged_user"
     )
+    """Tasks that this user is tagged in."""
 
     def __str__(self) -> str:
         return self.username

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -21,10 +21,16 @@ from .conftest import user_manager
 
 
 def test_object() -> None:
-    """The generated Object has expected properties."""
+    """The generated Object has expected properties, including object and field
+    descriptions pulled from model docstrings.
+    """
     type = user_manager.object
     assert type.name == "User"
+    assert type.description == "A user."
     assert type.fields.keys() == {"id", "username", "tasks", "tagged_tasks"}
+    assert type.fields["id"].description is None
+    assert type.fields["username"].description is not None
+    assert type.fields["tagged_tasks"].description is not None
     task_type = type.fields["tasks"].type
     assert isinstance(task_type, magql.NonNull)
     assert isinstance(task_type.type, magql.List)


### PR DESCRIPTION
Use `Model.__doc__` as the object's description. Use docstrings after attributes as the field/create+update argument description. This is a convention from documentation tools, but `attr.__doc__` is not present at runtime, so the AST has to be inspected instead. `inspect.cleandoc` is used to remove indentation.

closes #19 